### PR TITLE
nginxのログを収集できるようにしました

### DIFF
--- a/development/backend/src/api.js
+++ b/development/backend/src/api.js
@@ -4,7 +4,9 @@ const { v4: uuidv4 } = require('uuid');
 const jimp = require('jimp');
 
 const mysql = require('mysql2/promise');
+// debug用 提出前削除 関数内のperformance.markも忘れず削除
 const { performance, PerformanceObserver } = require('perf_hooks');
+///////////////////
 
 // MEMO: 設定項目はここを参考にした
 // https://github.com/sidorares/node-mysql2#api-and-configuration
@@ -110,6 +112,7 @@ const getItems = async (user, recordResult) => {
   return items;
 };
 
+// debug用 提出前削除
 // パフォーマンス測定関数
 // https://dev.to/bearer/measuring-performance-in-node-js-with-performance-hooks-585p
 const perfObserver = new PerformanceObserver((items) => {
@@ -119,6 +122,7 @@ const perfObserver = new PerformanceObserver((items) => {
 });
 
 perfObserver.observe({ entryTypes: ['measure'], buffer: true });
+//////////////////
 
 const getLinkedUser = async (headers) => {
   performance.mark('getlinkeduser-start');

--- a/development/docker-compose.yaml
+++ b/development/docker-compose.yaml
@@ -13,6 +13,7 @@ services:
             protocol: tcp
       volumes:
         - /da/tls:/etc/nginx/tls
+        - ../log/nginx_dev:/var/log/nginx
     backend:
       init: true
       build:

--- a/development/nginx/custom.conf
+++ b/development/nginx/custom.conf
@@ -1,3 +1,23 @@
+#### debug用 提出前に消す
+log_format ltsv "time:$time_local"
+                "\thost:$remote_addr"
+                "\tforwardedfor:$http_x_forwarded_for"
+                "\treq:$request"
+                "\tstatus:$status"
+                "\tmethod:$request_method"
+                "\turi:$request_uri"
+                "\tsize:$body_bytes_sent"
+                "\treferer:$http_referer"
+                "\tua:$http_user_agent"
+                "\treqtime:$request_time"
+                "\tcache:$upstream_http_x_cache"
+                "\truntime:$upstream_http_x_runtime"
+                "\tapptime:$upstream_response_time"
+                "\tvhost:$host";
+
+access_log /var/log/nginx/access.log ltsv;
+############################################
+
 server {
     listen 80;
     listen 443 ssl;

--- a/local/docker-compose-local.yaml
+++ b/local/docker-compose-local.yaml
@@ -8,6 +8,8 @@ services:
           - target: 80
             published: 8080
             protocol: tcp
+      volumes:
+           - ../log/nginx_local:/var/log/nginx
     backend:
       init: true
       build:

--- a/local/localNginx/custom.conf
+++ b/local/localNginx/custom.conf
@@ -1,3 +1,21 @@
+log_format ltsv "time:$time_local"
+                "\thost:$remote_addr"
+                "\tforwardedfor:$http_x_forwarded_for"
+                "\treq:$request"
+                "\tstatus:$status"
+                "\tmethod:$request_method"
+                "\turi:$request_uri"
+                "\tsize:$body_bytes_sent"
+                "\treferer:$http_referer"
+                "\tua:$http_user_agent"
+                "\treqtime:$request_time"
+                "\tcache:$upstream_http_x_cache"
+                "\truntime:$upstream_http_x_runtime"
+                "\tapptime:$upstream_response_time"
+                "\tvhost:$host";
+
+access_log /var/log/nginx/access.log ltsv;
+
 server {
     listen 80;
     #証明書はローカル環境に付属しない


### PR DESCRIPTION
* ./log/nginx_dev/にaccess.logとerror.logが作られる
* VMで `cat access.log | alp ltsv`などとすると、次の形式でログを確認できる

```
+-------+-----+-----+-----+-----+-----+--------+-------------------------------------+-------+-------+-------+-------+-------+-------+-------+--------+-----------+-----------+-----------+-----------+
| COUNT | 1XX | 2XX | 3XX | 4XX | 5XX | METHOD |                 URI                 |  MIN  |  MAX  |  SUM  |  AVG  |  P90  |  P95  |  P99  | STDDEV | MIN(BODY) | MAX(BODY) | SUM(BODY) | AVG(BODY) |
+-------+-----+-----+-----+-----+-----+--------+-------------------------------------+-------+-------+-------+-------+-------+-------+-------+--------+-----------+-----------+-----------+-----------+
|     5 |   0 |   5 |   0 |   0 |   0 | GET    | /api/client/record-views/tomeActive | 0.018 | 0.153 | 0.237 | 0.047 | 0.153 | 0.153 | 0.153 |  0.053 |  1460.000 |  1460.000 |  7300.000 |  1460.000 |
|     8 |   0 |   8 |   0 |   0 |   0 | GET    | /api/client/record-views/allActive  | 0.005 | 0.127 | 0.302 | 0.038 | 0.127 | 0.127 | 0.127 |  0.046 |    22.000 |    22.000 |   176.000 |    22.000 |
+-------+-----+-----+-----+-----+-----+--------+-------------------------------------+-------+-------+-------+-------+-------+-------+-------+--------+-----------+-----------+-----------+-----------+
```

alpのオプションについてはこちら：
https://github.com/tkuchiki/alp 